### PR TITLE
add protocol cli option

### DIFF
--- a/src/adminApi.js
+++ b/src/adminApi.js
@@ -4,8 +4,8 @@ require('isomorphic-fetch');
 
 let pluginSchemasCache;
 
-export default (host, protocol) => {
-    const router = createRouter(host, protocol);
+export default (host, https) => {
+    const router = createRouter(host, https);
 
     return {
         router,

--- a/src/adminApi.js
+++ b/src/adminApi.js
@@ -4,8 +4,8 @@ require('isomorphic-fetch');
 
 let pluginSchemasCache;
 
-export default host => {
-    const router = createRouter(host);
+export default (host, protocol) => {
+    const router = createRouter(host, protocol);
 
     return {
         router,

--- a/src/cli-apply.js
+++ b/src/cli-apply.js
@@ -8,7 +8,7 @@ program
     .version(require("../package.json").version)
     .option('--path <value>', 'Path to the configuration file')
     .option('--host <value>', 'Kong admin host (default: localhost:8001)')
-    .option('--protocol <value>', 'Kong admin protocol (default: http)')
+    .option('--https', 'Use https for admin API requests')
     .parse(process.argv);
 
 if (!program.path) {
@@ -18,7 +18,7 @@ if (!program.path) {
 
 let config = configLoader(program.path);
 let host = program.host || config.host || 'localhost:8001';
-let protocol = program.protocol || config.protocol || 'http';
+let https = program.https || config.https || false;
 
 if (!host) {
   console.log('Kong admin host must be specified in config or --host'.red);
@@ -27,7 +27,7 @@ if (!host) {
 
 console.log(`Apply config to ${host}`.green);
 
-execute(config, adminApi(host, protocol))
+execute(config, adminApi(host, https))
   .catch(error => {
       console.log(`${error}`.red, '\n', error.stack);
       process.exit(1);

--- a/src/cli-apply.js
+++ b/src/cli-apply.js
@@ -8,6 +8,7 @@ program
     .version(require("../package.json").version)
     .option('--path <value>', 'Path to the configuration file')
     .option('--host <value>', 'Kong admin host (default: localhost:8001)')
+    .option('--protocol <value>', 'Kong admin protocol (default: http)')
     .parse(process.argv);
 
 if (!program.path) {
@@ -17,6 +18,7 @@ if (!program.path) {
 
 let config = configLoader(program.path);
 let host = program.host || config.host || 'localhost:8001';
+let protocol = program.protocol || config.protocol || 'http';
 
 if (!host) {
   console.log('Kong admin host must be specified in config or --host'.red);
@@ -25,7 +27,7 @@ if (!host) {
 
 console.log(`Apply config to ${host}`.green);
 
-execute(config, adminApi(host))
+execute(config, adminApi(host, protocol))
   .catch(error => {
       console.log(`${error}`.red, '\n', error.stack);
       process.exit(1);

--- a/src/cli-dump.js
+++ b/src/cli-dump.js
@@ -9,7 +9,7 @@ program
     .version(require("../package.json").version)
     .option('-f, --format <value>', 'Export format [screen, json, yaml] (default: yaml)', /^(screen|json|yaml|yml)$/, 'yaml')
     .option('--host <value>', 'Kong admin host (default: localhost:8001)', 'localhost:8001')
-    .option('--protocol <value>', 'Kong admin protocol (default: http)', 'http')
+    .option('--https', 'Use https for admin API requests')
     .parse(process.argv);
 
 if (!program.host) {
@@ -17,9 +17,9 @@ if (!program.host) {
     process.exit(1);
 }
 
-readKongApi(adminApi(program.host, program.protocol))
+readKongApi(adminApi(program.host, program.https))
     .then(results => {
-        return {host: program.host, protocol: program.protocol, ...results};
+        return {host: program.host, https: program.https, ...results};
     })
     .then(pretty(program.format))
     .then(config => {

--- a/src/cli-dump.js
+++ b/src/cli-dump.js
@@ -9,6 +9,7 @@ program
     .version(require("../package.json").version)
     .option('-f, --format <value>', 'Export format [screen, json, yaml] (default: yaml)', /^(screen|json|yaml|yml)$/, 'yaml')
     .option('--host <value>', 'Kong admin host (default: localhost:8001)', 'localhost:8001')
+    .option('--protocol <value>', 'Kong admin protocol (default: http)', 'http')
     .parse(process.argv);
 
 if (!program.host) {
@@ -16,9 +17,9 @@ if (!program.host) {
     process.exit(1);
 }
 
-readKongApi(adminApi(program.host))
+readKongApi(adminApi(program.host, program.protocol))
     .then(results => {
-        return {host: program.host, ...results};
+        return {host: program.host, protocol: program.protocol, ...results};
     })
     .then(pretty(program.format))
     .then(config => {

--- a/src/core.js
+++ b/src/core.js
@@ -1,7 +1,6 @@
 'use strict';
 
 import colors from 'colors';
-import createAdminApi from './adminApi';
 import assign from 'object-assign';
 import kongState from './kongState';
 import {normalize as normalizeAttributes} from './utils';

--- a/src/router.js
+++ b/src/router.js
@@ -1,17 +1,18 @@
-export default function createRouter(host) {
+export default function createRouter(host, protocol) {
+    const adminApiRoot = `${protocol}://${host}`;
     return ({name, params}) => {
         switch (name) {
-            case 'apis': return `http://${host}/apis`;
-            case 'api': return `http://${host}/apis/${params.name}`;
-            case 'api-plugins': return `http://${host}/apis/${params.apiName}/plugins`;
-            case 'api-plugin': return `http://${host}/apis/${params.apiName}/plugins/${params.pluginId}`;
-            case 'consumers': return `http://${host}/consumers`;
-            case 'consumer': return `http://${host}/consumers/${params.username}`;
-            case 'consumer-credentials': return `http://${host}/consumers/${params.username}/${params.plugin}`;
-            case 'consumer-credential': return `http://${host}/consumers/${params.username}/${params.plugin}/${params.credentialId}`;
+            case 'apis': return `${adminApiRoot}/apis`;
+            case 'api': return `${adminApiRoot}/apis/${params.name}`;
+            case 'api-plugins': return `${adminApiRoot}/apis/${params.apiName}/plugins`;
+            case 'api-plugin': return `${adminApiRoot}/apis/${params.apiName}/plugins/${params.pluginId}`;
+            case 'consumers': return `${adminApiRoot}/consumers`;
+            case 'consumer': return `${adminApiRoot}/consumers/${params.username}`;
+            case 'consumer-credentials': return `${adminApiRoot}/consumers/${params.username}/${params.plugin}`;
+            case 'consumer-credential': return `${adminApiRoot}/consumers/${params.username}/${params.plugin}/${params.credentialId}`;
 
-            case 'plugins-enabled': return `http://${host}/plugins/enabled`;
-            case 'plugins-scheme': return `http://${host}/plugins/schema/${params.plugin}`;
+            case 'plugins-enabled': return `${adminApiRoot}/plugins/enabled`;
+            case 'plugins-scheme': return `${adminApiRoot}/plugins/schema/${params.plugin}`;
 
             default:
                 throw new Error(`Unknown route "${name}"`);

--- a/src/router.js
+++ b/src/router.js
@@ -1,4 +1,5 @@
-export default function createRouter(host, protocol) {
+export default function createRouter(host, https) {
+    const protocol = https ? 'https' : 'http';
     const adminApiRoot = `${protocol}://${host}`;
     return ({name, params}) => {
         switch (name) {


### PR DESCRIPTION
allows passing `--protocol https` when running `kongfig` for endpoints that are SSL enabled.  `protocol` defaults to `http`.