### PR TITLE
Added support for custom headers, which will be sent with all requests.

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -239,3 +239,29 @@ You are able to ensure that previous declarations have been removed, like so:
     ]
 }
 ```
+
+## Using Custom Headers
+
+You can specify any number of custom headers to be included with every request made by Kongfig.
+
+These can be used via the command line, like so:
+
+```bash
+kongfig apply --host localhost:8001 --path config.yaml --header apikey:secret --header name:value
+```
+
+or via the config file, like so:
+
+```yaml
+---
+  headers:
+    - 'apikey:secret'
+    - 'name:value'
+
+  apis:
+    -
+      name: "mockbin"
+      attributes:
+        upstream_url: "http://mockbin.com/"
+        request_host: "mockbin.com"
+```

--- a/src/adminApi.js
+++ b/src/adminApi.js
@@ -1,6 +1,5 @@
 import createRouter from './router';
-
-require('isomorphic-fetch');
+import requester from './requester';
 
 let pluginSchemasCache;
 let resultsCache = {};
@@ -36,7 +35,7 @@ function createApi({ router, getJson, ignoreConsumers }) {
         },
         requestEndpoint: (endpoint, params) => {
             resultsCache = {};
-            return fetch(router(endpoint), prepareOptions(params));
+            return requester.request(router(endpoint), prepareOptions(params));
         }
     };
 }
@@ -58,13 +57,7 @@ function getPluginScheme(plugin, schemaRoute) {
 }
 
 function getJson(uri) {
-    return fetch(uri, {
-        method: 'GET',
-        headers: {
-            'Connection': 'keep-alive',
-            'Accept': 'application/json'
-        }
-    })
+    return requester.get(uri)
     .then(r => r.json())
     .then(json => {
         if (json.next) {

--- a/src/cli-apply.js
+++ b/src/cli-apply.js
@@ -3,6 +3,7 @@ import adminApi from './adminApi';
 import colors from 'colors';
 import configLoader from './configLoader';
 import program from 'commander';
+import requester from './requester';
 
 program
     .version(require("../package.json").version)
@@ -11,6 +12,7 @@ program
     .option('--https', 'Use https for admin API requests')
     .option('--no-cache', 'Do not cache kong state in memory')
     .option('--ignore-consumers', 'Do not sync consumers')
+    .option('--header [value]', 'Custom headers to be added to all requests', (nextHeader, headers) => { headers.push(nextHeader); return headers }, [])
     .parse(process.argv);
 
 if (!program.path) {
@@ -23,6 +25,11 @@ let host = program.host || config.host || 'localhost:8001';
 let https = program.https || config.https || false;
 let ignoreConsumers = program.ignoreConsumers || !config.consumers || config.consumers.length === 0 || false;
 let cache = program.cache;
+let headers = program.header.length > 0 ? program.header : (config.headers || []);
+
+headers
+    .map((h) => h.split(':'))
+    .forEach(([name, value]) => requester.addHeader(name, value));
 
 if (!host) {
   console.log('Kong admin host must be specified in config or --host'.red);

--- a/src/cli-apply.js
+++ b/src/cli-apply.js
@@ -25,11 +25,16 @@ let host = program.host || config.host || 'localhost:8001';
 let https = program.https || config.https || false;
 let ignoreConsumers = program.ignoreConsumers || !config.consumers || config.consumers.length === 0 || false;
 let cache = program.cache;
-let headers = program.header.length > 0 ? program.header : (config.headers || []);
+
+config.headers = config.headers || [];
+
+let headers = new Map();
+([...config.headers, ...program.header])
+  .map((h) => h.split(':'))
+  .forEach(([name, value]) => headers.set(name, value));
 
 headers
-    .map((h) => h.split(':'))
-    .forEach(([name, value]) => requester.addHeader(name, value));
+  .forEach((value, name) => requester.addHeader(name, value));
 
 if (!host) {
   console.log('Kong admin host must be specified in config or --host'.red);

--- a/src/requester.js
+++ b/src/requester.js
@@ -1,0 +1,41 @@
+require('isomorphic-fetch');
+
+let headers = {};
+
+const addHeader = (name, value) => { headers[name] = value };
+const clearHeaders = () => { headers = {} };
+
+const get = (uri) => {
+    const options = {
+        method: 'GET',
+        headers: {
+            'Connection': 'keep-alive',
+            'Accept': 'application/json'
+        }
+    };
+
+    return request(uri, options);
+};
+
+const request = (uri, opts) => {
+    const requestHeaders = Object.assign(
+        {},
+        opts.headers,
+        headers
+    );
+
+    const options = Object.assign(
+        {},
+        opts,
+        { headers: requestHeaders }
+    );
+
+    return fetch(uri, options);
+};
+
+export default {
+    addHeader,
+    clearHeaders,
+    get,
+    request
+};

--- a/test/index.js
+++ b/test/index.js
@@ -2,4 +2,5 @@ require("babel-polyfill");
 
 require('./apis.js');
 require('./consumers.js');
+require('./requester.js');
 require('./utils.js');

--- a/test/requester.js
+++ b/test/requester.js
@@ -1,0 +1,134 @@
+import expect from 'expect.js';
+import requester from '../src/requester.js';
+
+let actualRequest = {};
+
+global.fetch = (url, options) => {
+    actualRequest = {
+        url,
+        options
+    };
+};
+
+describe('requester', () => {
+    beforeEach(() => {
+        actualRequest = {};
+        requester.clearHeaders();
+    });
+
+    it('should get', () => {
+        const expectedRequest = {
+            url: 'http://example.com',
+            options: {
+              method: 'GET',
+              headers: {
+                  'Connection': 'keep-alive',
+                  'Accept': 'application/json'
+              }
+            }
+        };
+
+        requester.get('http://example.com');
+
+        expect(actualRequest).to.be.eql(expectedRequest);
+    });
+
+    it('should get with custom headers', () => {
+        const expectedRequest = {
+            url: 'http://example.com',
+            options: {
+              method: 'GET',
+              headers: {
+                  'Connection': 'keep-alive',
+                  'Accept': 'application/json',
+                  'CustomHeader1': 'CustomValue1',
+                  'CustomHeader2': 'CustomValue2'
+              }
+            }
+        };
+
+        requester.addHeader('CustomHeader1', 'CustomValue1');
+        requester.addHeader('CustomHeader2', 'CustomValue2');
+        requester.get('http://example.com');
+
+        expect(actualRequest).to.be.eql(expectedRequest);
+    });
+
+    it('should make requests', () => {
+        const expectedRequest = {
+            url: 'http://example.com',
+            options: {
+              method: 'POST',
+              headers: {
+                  'Connection': 'keep-alive',
+                  'Accept': 'application/json',
+                  'Content-Type': 'application/json'
+              },
+              body: 'This is the body'
+            }
+        };
+
+        requester.request('http://example.com', {
+            method: 'POST',
+            body: 'This is the body',
+            headers: {
+                'Connection': 'keep-alive',
+                'Accept': 'application/json',
+                'Content-Type': 'application/json'
+            }
+          });
+
+        expect(actualRequest).to.be.eql(expectedRequest);
+    });
+
+    it('should make requests with custom headers', () => {
+        const expectedRequest = {
+            url: 'http://example.com',
+            options: {
+              method: 'POST',
+              headers: {
+                  'Connection': 'keep-alive',
+                  'Accept': 'application/json',
+                  'Content-Type': 'application/json',
+                  'CustomHeader1': 'CustomValue1',
+                  'CustomHeader2': 'CustomValue2'
+              },
+              body: 'This is the body'
+            }
+        };
+
+        requester.addHeader('CustomHeader1', 'CustomValue1');
+        requester.addHeader('CustomHeader2', 'CustomValue2');
+        requester.request('http://example.com', {
+            method: 'POST',
+            body: 'This is the body',
+            headers: {
+                'Connection': 'keep-alive',
+                'Accept': 'application/json',
+                'Content-Type': 'application/json'
+            }
+          });
+
+        expect(actualRequest).to.be.eql(expectedRequest);
+    });
+
+    it('should clear headers', () => {
+      const expectedRequest = {
+          url: 'http://example.com',
+          options: {
+            method: 'GET',
+            headers: {
+                'Connection': 'keep-alive',
+                'Accept': 'application/json'
+            }
+          }
+      };
+
+      requester.addHeader('CustomHeader1', 'CustomValue1');
+      requester.addHeader('CustomHeader2', 'CustomValue2');
+      requester.clearHeaders();
+      requester.get('http://example.com');
+
+      expect(actualRequest).to.be.eql(expectedRequest);
+    });
+});


### PR DESCRIPTION
In order to enable support for several types of authentication, in particular key-auth.

For example, if the admin endpoint is secured using Kong itself (via a loopback: https://docs.gelato.io/guides/advanced-kong-integration) it looks like basic-auth works with -- host user:pass@host (as suggested in #31), but this adds another way to perform the authentication. Credentials can be saved to the config file rather than having to be added to the command line each time.

Multiple custom headers can be supplied via the command line for both the apply and dump commands, and via the config file for the apply command. Examples are included in the docs.

We have added a new 'requester' module to handle the getJson/fetch requests. The module includes 'addHeader' and 'clearHeaders' methods for managing the custom headers. Any headers added via this method will be merged with the current defaults (Accept, Content-Type), with those specified via command line or config file taking precedence.