### PR TITLE
Add support for custom consumer credential plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,18 @@ You can specify the desired format by giving `--format` option with possible opt
 kongfig dump --format screen
 ```
 
+For APIs which uses custom consumer credential pluings, specify plugin and id name in <plugin>:<idValue> format with `--credential-schema` option.
+
+```
+kongfig apply --path config.yml --host localhost:8001 --credential-schema custom_jwt:key
+```
+
+For multiple plugins use --credential-schema as many as necessary
+
+```
+kongfig apply --path config.yml --host localhost:8001 --credential-schema "custom_jwt:key" --credential-schema "custom_oauth2:client_id"
+```
+
 ## Schema
 
 Api schema:
@@ -229,6 +241,35 @@ consumers:
           key: # required
           secret:
 ```
+
+### Custom Credential Schemas
+
+It is possible to work with custom consumer credential plugins.
+
+```yaml
+apis:
+  - name: mockbin
+    attributes: # ...
+    plugins:
+      - name: custom_jwt
+        attributes:
+          config:
+            uri_param_names:
+            claims_to_verify:
+
+consumers:
+  - username: iphone-app
+    credentials:
+      - name: custom_jwt
+        attributes:
+          key: # required
+          secret:
+
+credentialSchema:
+  custom_jwt:
+    id: "key" # credential id name           
+```
+
 
 ### ACL Support
 

--- a/config.js.sample
+++ b/config.js.sample
@@ -43,5 +43,10 @@ module.exports = {
             username: "ie",
             ensure: "removed"
         }
-    ]
+    ],
+    credentialSchemas: {
+        custom_jwt: {
+          id: "key"
+        }
+    }
 };

--- a/config.json.sample
+++ b/config.json.sample
@@ -43,5 +43,10 @@
             "username": "ie",
             "ensure": "removed"
         }
-    ]
+    ],
+    "credentialSchemas": {
+        "custom_jwt": {
+          "id": "key"
+        }
+    }
 }

--- a/config.yml.sample
+++ b/config.yml.sample
@@ -26,3 +26,7 @@
 
     - username: "ie"
       ensure: "removed"
+
+ credentialSchemas:
+   custom_jwt:
+    id: key

--- a/src/cli-apply.js
+++ b/src/cli-apply.js
@@ -4,6 +4,8 @@ import colors from 'colors';
 import configLoader from './configLoader';
 import program from 'commander';
 import requester from './requester';
+import {repeatableOptionCallback} from './utils';
+import {addSchemasFromOptions, addSchemasFromConfig} from './consumerCredentials';
 
 program
     .version(require("../package.json").version)
@@ -13,11 +15,19 @@ program
     .option('--no-cache', 'Do not cache kong state in memory')
     .option('--ignore-consumers', 'Do not sync consumers')
     .option('--header [value]', 'Custom headers to be added to all requests', (nextHeader, headers) => { headers.push(nextHeader); return headers }, [])
+    .option('--credential-schema <value>', 'Add custom auth plugin in <name>:<key> format. Ex: custom_jwt:key. Repeat option for multiple custom plugins', repeatableOptionCallback, [])
     .parse(process.argv);
 
 if (!program.path) {
   console.log('--path to the config file is required'.red);
   process.exit(1);
+}
+
+try{
+    addSchemasFromOptions(program.credentialSchema);
+}catch(e){
+    console.log(e.message.red);
+    process.exit(1);
 }
 
 let config = configLoader(program.path);
@@ -43,6 +53,14 @@ if (!host) {
 
 if (ignoreConsumers) {
     config.consumers = [];
+}
+else {
+  try{
+      addSchemasFromConfig(config);
+  } catch(e) {
+      console.log(e.message.red);
+      process.exit(1);
+  }
 }
 
 console.log(`Apply config to ${host}`.green);

--- a/src/cli-dump.js
+++ b/src/cli-dump.js
@@ -3,6 +3,8 @@ import {pretty} from './prettyConfig';
 import adminApi from './adminApi';
 import colors from 'colors';
 import requester from './requester';
+import {repeatableOptionCallback} from './utils';
+import {addSchemasFromOptions} from './consumerCredentials';
 
 import program from 'commander';
 
@@ -13,10 +15,18 @@ program
     .option('--https', 'Use https for admin API requests')
     .option('--ignore-consumers', 'Ignore consumers in kong')
     .option('--header [value]', 'Custom headers to be added to all requests', (nextHeader, headers) => { headers.push(nextHeader); return headers }, [])
+    .option('--credential-schema <value>', 'Add custom auth plugin in <name>:<key> format. Ex: custom_jwt:key. Repeat option for multiple custom plugins', repeatableOptionCallback, [])
     .parse(process.argv);
 
 if (!program.host) {
     console.log('--host to the kong admin is required e.g. localhost:8001'.red);
+    process.exit(1);
+}
+
+try {
+    addSchemasFromOptions(program.credentialSchema);
+} catch(e){
+    console.log(e.message.red);
     process.exit(1);
 }
 

--- a/src/consumerCredentials.js
+++ b/src/consumerCredentials.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const schema = {
+    'oauth2': {
+        id: 'client_id'
+    },
+    'key-auth': {
+        id: 'key'
+    },
+    'jwt': {
+        id: 'key'
+    },
+    'basic-auth': {
+        id: 'username'
+    },
+    'hmac-auth': {
+        id: 'username'
+    }
+};
+
+export function getSupportedCredentials() {
+    return Object.keys(schema);
+}
+
+export function getSchema(name) {
+    if (false === schema.hasOwnProperty(name)) {
+        throw new Error(`Unknown credential "${name}"`);
+    }
+
+    return schema[name];
+}
+
+export function addSchema(name, val){
+    if (schema.hasOwnProperty(name)){
+        throw new Error(`There is already a schema with name '${name}'`);
+    }
+    if (!val || !val.hasOwnProperty('id')){
+        throw new Error(`Credential schema ${name} should have a property named "id"`);
+    }
+    schema[name] = val;
+}
+
+export function addSchemasFromOptions(opts){
+    if (!opts || opts.length === 0) return;
+
+    opts.forEach(val => {
+        var vals = val.split(':');
+        if (vals.length != 2) {
+            throw new Error(`Use <pluginname>:<keyname> format in ${val}`);
+        }
+        addSchema(vals[0], {id: vals[1]});
+    });
+}
+
+export function addSchemasFromConfig(config){
+    if (!config.credentialSchemas) return;
+
+    for (let key in config.credentialSchemas){
+        addSchema(key, config.credentialSchemas[key]);
+    }
+}

--- a/src/core.js
+++ b/src/core.js
@@ -3,6 +3,7 @@
 import colors from 'colors';
 import assign from 'object-assign';
 import kongState from './kongState';
+import {getSchema as getConsumerCredentialSchema} from './consumerCredentials';
 import {normalize as normalizeAttributes} from './utils';
 import {
     noop,
@@ -21,39 +22,10 @@ import {
     removeConsumerAcls
 } from './actions';
 
-export const consumerCredentialSchema = {
-    oauth2: {
-        id: 'client_id'
-    },
-    'key-auth': {
-        id: 'key'
-    },
-    'jwt': {
-        id: 'key'
-    },
-    'basic-auth': {
-        id: 'username'
-    },
-    'hmac-auth': {
-        id: 'username'
-    }
-};
-
 export const consumerAclSchema = {
     id: 'group'
 };
 
-export function getSupportedCredentials() {
-    return Object.keys(consumerCredentialSchema);
-}
-
-export function getCredentialSchema(name) {
-    if (false === consumerCredentialSchema.hasOwnProperty(name)) {
-        throw new Error(`Unknown credential "${name}"`);
-    }
-
-    return consumerCredentialSchema[name];
-}
 
 export function getAclSchema() {
     return consumerAclSchema;
@@ -173,7 +145,7 @@ function _createWorld({apis, consumers}) {
             return consumers.some(consumer => consumer.username === username);
         },
         hasConsumerCredential: (username, name, attributes) => {
-            const schema = getCredentialSchema(name);
+            const schema = getConsumerCredentialSchema(name);
 
             return consumers.some(
                 c => c.username === username
@@ -270,7 +242,7 @@ function _createWorld({apis, consumers}) {
 }
 
 function extractCredentialId(credentials, name, attributes) {
-    const idName = getCredentialSchema(name).id;
+    const idName = getConsumerCredentialSchema(name).id;
 
     return credentials[name].find(x => x[idName] == attributes[idName]);
 }
@@ -424,7 +396,7 @@ function _consumerCredential(username, credential) {
             const credentialId = world.getConsumerCredentialId(username, credential.name, credential.attributes);
 
             if (world.isConsumerCredentialUpToDate(username, credential)) {
-                const credentialIdName = getCredentialSchema(credential.name).id;
+                const credentialIdName = getConsumerCredentialSchema(credential.name).id;
                 console.log("  - credential", `${credential.name}`.bold, `with ${credentialIdName}:`, `${credential.attributes[credentialIdName]}`.bold, "is up-to-date".green);
 
                 return noop();
@@ -438,7 +410,7 @@ function _consumerCredential(username, credential) {
 }
 
 function validateCredentialRequiredAttributes(credential) {
-    const credentialIdName = getCredentialSchema(credential.name).id;
+    const credentialIdName = getConsumerCredentialSchema(credential.name).id;
 
     if (false == credential.hasOwnProperty('attributes')) {
         throw Error(`${credential.name} has to declare attributes.${credentialIdName}`);

--- a/src/kongState.js
+++ b/src/kongState.js
@@ -1,4 +1,4 @@
-import {getSupportedCredentials} from './core'
+import {getSupportedCredentials} from './consumerCredentials'
 
 export default async ({fetchApis, fetchPlugins, fetchConsumers, fetchConsumerCredentials, fetchConsumerAcls}) => {
     const apis = await fetchApis();

--- a/src/utils.js
+++ b/src/utils.js
@@ -33,3 +33,8 @@ function _setOnPath(obj, path, value){
 
     return _setOnPath(obj[currentPath], path.slice(1), value);
 }
+
+export function repeatableOptionCallback(val, result){
+    result.push(val);
+    return result;
+}


### PR DESCRIPTION
I am not a native english speaker. Parameter names and additons to 
documentation may need changes.

Add custom plugin schema using --credential-schema <pluginname>:<idname> option.
```
kongfig apply --path config.yml --host localhost:8001 --credential-schema custom_jwt:key
```

You may also define it in config file:
```yml
credentialSchema:
  custom_jwt:
    id: "key" # credential id name 
```

Unfortunately currently this config option can not be created by dump command.