### PR TITLE
Added pagination of consumers, plus check for non array

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -113,7 +113,7 @@ function _bindWorldState(adminApi) {
 
 function _createWorld({apis, consumers}) {
     const world = {
-        hasApi: apiName => apis.some(api => api.name === apiName),
+        hasApi: apiName => Array.isArray(apis) && apis.some(api => api.name === apiName),
         getApi: apiName => {
             const api = apis.find(api => api.name === apiName);
 
@@ -139,23 +139,24 @@ function _createWorld({apis, consumers}) {
             return world.getPlugin(apiName, pluginName).config;
         },
         hasPlugin: (apiName, pluginName) => {
-            return apis.some(api => api.name === apiName && api.plugins.some(plugin => plugin.name == pluginName));
+            return Array.isArray(apis) && apis.some(api => api.name === apiName && Array.isArray(api.plugins) && api.plugins.some(plugin => plugin.name == pluginName));
         },
         hasConsumer: (username) => {
-            return consumers.some(consumer => consumer.username === username);
+            return Array.isArray(consumers) && consumers.some(consumer => consumer.username === username);
         },
         hasConsumerCredential: (username, name, attributes) => {
             const schema = getConsumerCredentialSchema(name);
 
-            return consumers.some(
+            return Array.isArray(consumers) && consumers.some(
                 c => c.username === username
+                && Array.isArray(c.credentials[name])
                 && c.credentials[name].some(oa => oa[schema.id] == attributes[schema.id]));
         },
         hasConsumerAcl: (username, groupName) => {
             const schema = getAclSchema();
 
-            return consumers.some(function (consumer) {
-                return consumer.acls.some(function (acl) {
+            return Array.isArray(consumers) && consumers.some(function (consumer) {
+                return Array.isArray(consumer.acls) && consumer.acls.some(function (acl) {
                     return consumer.username === username && acl[schema.id] == groupName;
                 });
             });

--- a/src/readKongApi.js
+++ b/src/readKongApi.js
@@ -18,7 +18,7 @@ function parseConsumers(consumers) {
         return {
             username,
             _info,
-            acls: acls.map(({group, ..._info}) => ({group, _info})),
+            acls: Array.isArray(acls) ? acls.map(({group, ..._info}) => ({group, _info})) : [],
             credentials: zip(Object.keys(credentials), Object.values(credentials))
                 .map(parseCredential)
                 .reduce((acc, x) => acc.concat(x), [])
@@ -31,6 +31,7 @@ function zip(a, b) {
 }
 
 function parseCredential([credentialName, credentials]) {
+    if(!Array.isArray(credentials)) return [];
     return credentials.map(({consumer_id, id, created_at, ...attributes}) => {
         return {
             name: credentialName,


### PR DESCRIPTION
Initially for #30 
- added pagination (recursively call with next url and add to results)
- added check for array so wont throw map error when acl isnt found, returns empty array if not.


Please review. After you give the go ahead I will implement the caching much like getJson in adminApi.js

I have tested on a kong v: 0.8.0 with 500 + consumers.

May solve: #43 #33 #32 