### PR TITLE
Support for global plugins.

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -50,6 +50,29 @@ export function updateApiPlugin(apiName, pluginId, params) {
     };
 }
 
+export function addGlobalPlugin(pluginName, params) {
+    return {
+        endpoint: {name: 'plugins', params: {pluginName}},
+        method: 'POST',
+        body: assign({}, params, {name: pluginName})
+    };
+}
+
+export function removeGlobalPlugin(pluginId) {
+    return {
+        endpoint: {name: 'plugin', params: {pluginId}},
+        method: 'DELETE',
+    };
+}
+
+export function updateGlobalPlugin(pluginId, params) {
+    return {
+        endpoint: {name: 'plugin', params: {pluginId}},
+        method: 'PATCH',
+        body: params
+    };
+}
+
 export function createConsumer(username) {
         return {
         endpoint: { name: 'consumers' },

--- a/src/adminApi.js
+++ b/src/adminApi.js
@@ -18,6 +18,7 @@ function createApi({ router, getPaginatedJson, ignoreConsumers }) {
     return {
         router,
         fetchApis: () => getPaginatedJson(router({name: 'apis'})),
+        fetchGlobalPlugins: () => getPaginatedJson(router({name: 'plugins'})),
         fetchPlugins: apiName => getPaginatedJson(router({name: 'api-plugins', params: {apiName}})),
         fetchConsumers: () => ignoreConsumers ? Promise.resolve([]) : getPaginatedJson(router({name: 'consumers'})),
         fetchConsumerCredentials: (username, plugin) => getPaginatedJson(router({name: 'consumer-credentials', params: {username, plugin}})),

--- a/src/kongState.js
+++ b/src/kongState.js
@@ -1,6 +1,6 @@
 import {getSupportedCredentials} from './consumerCredentials'
 
-export default async ({fetchApis, fetchPlugins, fetchConsumers, fetchConsumerCredentials, fetchConsumerAcls}) => {
+export default async ({fetchApis, fetchPlugins, fetchGlobalPlugins, fetchConsumers, fetchConsumerCredentials, fetchConsumerAcls}) => {
     const apis = await fetchApis();
     const apisWithPlugins = await Promise.all(apis.map(async item => {
         const plugins =  await fetchPlugins(item.name);
@@ -39,8 +39,14 @@ export default async ({fetchApis, fetchPlugins, fetchConsumers, fetchConsumerCre
 
     }));
 
+    const allPlugins = await fetchGlobalPlugins();
+    const globalPlugins = allPlugins.filter(plugin => {
+        return plugin.api_id === undefined && plugin.consumer_id === undefined;
+    });
+
     return {
         apis: apisWithPlugins,
-        consumers: consumersWithCredentialsAndAcls
+        consumers: consumersWithCredentialsAndAcls,
+        plugins: globalPlugins
     };
 };

--- a/src/readKongApi.js
+++ b/src/readKongApi.js
@@ -5,10 +5,12 @@ export default async (adminApi) => {
         .then(([state, schemas]) => {
             const prepareConfig = (plugin, config) => stripConfig(config, schemas.get(plugin));
             const parseApiPluginsForSchemes = plugins => parseApiPlugins(plugins, prepareConfig);
+            const parsePluginsForSchemes = plugins => parseGlobalPlugins(plugins, prepareConfig);
 
             return {
                 apis: parseApis(state.apis, parseApiPluginsForSchemes),
-                consumers: parseConsumers(state.consumers)
+                consumers: parseConsumers(state.consumers),
+                plugins: parsePluginsForSchemes(state.plugins)
             }
         })
 };
@@ -78,6 +80,28 @@ function parseApiPlugins(plugins, prepareConfig) {
             _info: {
                 id,
                 //api_id,
+                consumer_id,
+                enabled,
+                created_at
+            }
+        };
+    });
+}
+
+function parseGlobalPlugins(plugins, prepareConfig) {
+    return plugins.map(({
+        name,
+        config,
+        id, api_id, consumer_id, enabled, created_at
+    }) => {
+        return {
+            name,
+            attributes: {
+                config: prepareConfig(name, config)
+            },
+            _info: {
+                id,
+                api_id,
                 consumer_id,
                 enabled,
                 created_at

--- a/src/router.js
+++ b/src/router.js
@@ -14,6 +14,8 @@ export default function createRouter(host, https) {
             case 'consumer-acls': return `${adminApiRoot}/consumers/${params.username}/acls`;
             case 'consumer-acl': return `${adminApiRoot}/consumers/${params.username}/acls/${params.aclId}`;
 
+            case 'plugins': return `${adminApiRoot}/plugins`;
+            case 'plugin': return `${adminApiRoot}/plugins/${params.pluginId}`;
             case 'plugins-enabled': return `${adminApiRoot}/plugins/enabled`;
             case 'plugins-scheme': return `${adminApiRoot}/plugins/schema/${params.plugin}`;
 

--- a/test/index.js
+++ b/test/index.js
@@ -4,3 +4,4 @@ require('./apis.js');
 require('./consumers.js');
 require('./requester.js');
 require('./utils.js');
+require('./plugins.js');

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -1,0 +1,68 @@
+import expect from 'expect.js';
+import {apis, plugins, globalPlugins} from '../src/core.js';
+import {
+    noop,
+    addGlobalPlugin,
+    removeGlobalPlugin,
+    updateGlobalPlugin
+} from '../src/actions.js';
+
+describe("plugins", () => {
+    it("should add new global plugin", () => {
+        var actual = globalPlugins([{
+            "ensure": "present",
+            "name": "cors",
+            "attributes": {
+                'config.foo': "bar"
+            }
+        }])
+        .map(x => x({hasGlobalPlugin: () => false}));
+
+        expect(actual).to.be.eql([
+            addGlobalPlugin('cors', {'config.foo': "bar"})
+        ]);
+    });
+
+    it("should remove a global plugin", () => {
+        var actual = globalPlugins([{
+            "name": "cors",
+            "ensure": "removed",
+            "attributes": {
+                'config.foo': "bar"
+            }
+        }])
+        .map(x => x({
+                    hasGlobalPlugin: () => true,
+                    getGlobalPluginId: () => 123
+                    }));
+
+        expect(actual).to.be.eql([
+            removeGlobalPlugin(123)
+        ]);
+    });
+
+    it('should update a global plugin', () => {
+        var actual = globalPlugins([{
+            'name': 'cors',
+            'attributes': {
+                'config.foo': 'bar'
+            }}]
+        ).map(x => x({
+            hasGlobalPlugin: () => true,
+            getGlobalPluginId: () => 123,
+            isGlobalPluginUpToDate: () => false
+        }));
+
+        expect(actual).to.be.eql([
+            updateGlobalPlugin(123, {'config.foo': 'bar'})
+        ]);
+    });
+
+    it("should validate ensure enum", () => {
+        expect(() => globalPlugins([{
+            "ensure": "not-valid",
+            "name": "cors"
+        }])).to.throwException(/Invalid ensure/);
+    });
+
+});


### PR DESCRIPTION
Kong added support for global plugins that you can define on the top level. They are applied to all proxies automatically. Without this change, there is no way to define those global plugins with Kong, nor to dump their configuration. 

This fixes https://github.com/mybuilder/kongfig/issues/50