### PR TITLE
Adding support for v0.10 /apis schema with backwards-compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "js-yaml": "^3.4.6",
     "minimist": "^1.2.0",
     "object-assign": "^4.0.1",
-    "prettyjson": "^1.1.3"
+    "prettyjson": "^1.1.3",
+    "semver": "^5.3.0"
   },
   "devDependencies": {
     "babel-core": "^6.2.1",

--- a/src/adminApi.js
+++ b/src/adminApi.js
@@ -2,6 +2,7 @@ import createRouter from './router';
 import requester from './requester';
 
 let pluginSchemasCache;
+let kongVersionCache;
 let resultsCache = {};
 
 export default ({host, https, ignoreConsumers, cache}) => {
@@ -33,6 +34,15 @@ function createApi({ router, getPaginatedJson, ignoreConsumers }) {
             return getPaginatedJson(router({name: 'plugins-enabled'}))
                 .then(json => Promise.all(getEnabledPluginNames(json.enabled_plugins).map(plugin => getPluginScheme(plugin, plugin => router({name: 'plugins-scheme', params: {plugin}})))))
                 .then(all => pluginSchemasCache = new Map(all));
+        },
+        fetchKongVersion: () => {
+            if (kongVersionCache) {
+                return Promise.resolve(kongVersionCache);
+            }
+
+            return getPaginatedJson(router({name: 'root'}))
+                .then(json => Promise.resolve(json.version))
+                .then(version => kongVersionCache = version);
         },
         requestEndpoint: (endpoint, params) => {
             resultsCache = {};

--- a/src/router.js
+++ b/src/router.js
@@ -19,6 +19,8 @@ export default function createRouter(host, https) {
             case 'plugins-enabled': return `${adminApiRoot}/plugins/enabled`;
             case 'plugins-scheme': return `${adminApiRoot}/plugins/schema/${params.plugin}`;
 
+            case 'root': return `${adminApiRoot}`;
+
             default:
                 throw new Error(`Unknown route "${name}"`);
         }


### PR DESCRIPTION
This change figures out against which Kong version it's running when parsing the output returned from `/apis` (different behavior for pre-0.10 and post-0.10). 

It's one of the possible fixes for https://github.com/mybuilder/kongfig/issues/63