### PR TITLE
Ensure consumers are modified before any other config changes are made

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -39,8 +39,8 @@ export function getAclSchema() {
 
 export default async function execute(config, adminApi) {
     const actions = [
-        ...apis(config.apis),
         ...consumers(config.consumers),
+        ...apis(config.apis),
         ...globalPlugins(config.plugins)
     ];
 


### PR DESCRIPTION
Consumer information can be used in config for apis and plugins. Its essential an modifications (especially creation) happens before modifying the dependent apis. 