### PR TITLE
Write error messages to STDERR

### DIFF
--- a/src/cli-apply.js
+++ b/src/cli-apply.js
@@ -19,14 +19,14 @@ program
     .parse(process.argv);
 
 if (!program.path) {
-  console.log('--path to the config file is required'.red);
+  console.error('--path to the config file is required'.red);
   process.exit(1);
 }
 
 try{
     addSchemasFromOptions(program.credentialSchema);
 }catch(e){
-    console.log(e.message.red);
+    console.error(e.message.red);
     process.exit(1);
 }
 
@@ -47,7 +47,7 @@ headers
   .forEach((value, name) => requester.addHeader(name, value));
 
 if (!host) {
-  console.log('Kong admin host must be specified in config or --host'.red);
+  console.error('Kong admin host must be specified in config or --host'.red);
   process.exit(1);
 }
 
@@ -58,7 +58,7 @@ else {
   try{
       addSchemasFromConfig(config);
   } catch(e) {
-      console.log(e.message.red);
+      console.error(e.message.red);
       process.exit(1);
   }
 }
@@ -67,6 +67,6 @@ console.log(`Apply config to ${host}`.green);
 
 execute(config, adminApi({host, https, ignoreConsumers, cache}))
   .catch(error => {
-      console.log(`${error}`.red, '\n', error.stack);
+      console.error(`${error}`.red, '\n', error.stack);
       process.exit(1);
   });

--- a/src/cli-dump.js
+++ b/src/cli-dump.js
@@ -19,14 +19,14 @@ program
     .parse(process.argv);
 
 if (!program.host) {
-    console.log('--host to the kong admin is required e.g. localhost:8001'.red);
+    console.error('--host to the kong admin is required e.g. localhost:8001'.red);
     process.exit(1);
 }
 
 try {
     addSchemasFromOptions(program.credentialSchema);
 } catch(e){
-    console.log(e.message.red);
+    console.error(e.message.red);
     process.exit(1);
 }
 
@@ -45,6 +45,6 @@ readKongApi(adminApi({ host: program.host, https: program.https, ignoreConsumers
         process.stdout.write(config + '\n');
     })
     .catch(error => {
-        console.log(`${error}`.red, '\n', error.stack);
+        console.error(`${error}`.red, '\n', error.stack);
         process.exit(1);
     });

--- a/src/configLoader.js
+++ b/src/configLoader.js
@@ -4,7 +4,7 @@ import yaml from 'js-yaml';
 
 const log = {
     info: message => console.log(message.green),
-    error: message => console.log(message.red)
+    error: message => console.error(message.red)
 }
 
 export default (configPath) => {


### PR DESCRIPTION
Currently both error and general log messages are written to STDOUT. This can cause issues for people relying on i/o redirection to treat STDOUT/STDERR differently.

eg. Before this change the following erroneous command would produce no feedback as any errors would be written to `config.yml`
```
# kongfig dump config --host invalidhost:8001 > config.yml
```

After this change the same command will result in error messages being written to the console.
```
# kongfig dump config --host invalidhost:8001 > config.yml
FetchError: request to http://throwerror:8001 failed, reason: getaddrinfo ENOTFOUND throwerror throwerror:8001
 Error
    at ClientRequest.<anonymous> (/work/node_modules/node-fetch/index.js:133:11)
    at emitOne (events.js:115:13)
    at ClientRequest.emit (events.js:210:7)
    at Socket.socketErrorListener (_http_client.js:399:9)
    at emitOne (events.js:115:13)
    at Socket.emit (events.js:210:7)
    at emitErrorNT (internal/streams/destroy.js:62:8)
    at _combinedTickCallback (internal/process/next_tick.js:102:11)
    at process._tickCallback (internal/process/next_tick.js:161:9)
```