### PR TITLE
Add support for username and custom_id mapping

### DIFF
--- a/src/adminApi.js
+++ b/src/adminApi.js
@@ -15,13 +15,13 @@ export default ({host, https, ignoreConsumers, cache}) => {
     });
 }
 
-function createApi({ router, getPaginatedJson, ignoreConsumers }) {
+function createApi({ router, getPaginatedJson }) {
     return {
         router,
         fetchApis: () => getPaginatedJson(router({name: 'apis'})),
         fetchGlobalPlugins: () => getPaginatedJson(router({name: 'plugins'})),
         fetchPlugins: apiId => getPaginatedJson(router({name: 'api-plugins', params: {apiId}})),
-        fetchConsumers: () => ignoreConsumers ? Promise.resolve([]) : getPaginatedJson(router({name: 'consumers'})),
+        fetchConsumers: () =>  getPaginatedJson(router({name: 'consumers'})),
         fetchConsumerCredentials: (consumerId, plugin) => getPaginatedJson(router({name: 'consumer-credentials', params: {consumerId, plugin}})),
         fetchConsumerAcls: (consumerId) => getPaginatedJson(router({name: 'consumer-acls', params: {consumerId}})),
 

--- a/src/cli-dump.js
+++ b/src/cli-dump.js
@@ -5,12 +5,14 @@ import colors from 'colors';
 import requester from './requester';
 import {repeatableOptionCallback} from './utils';
 import {addSchemasFromOptions} from './consumerCredentials';
+import mapConsumers from './mapConsumers';
 
 import program from 'commander';
 
 program
     .version(require("../package.json").version)
     .option('-f, --format <value>', 'Export format [screen, json, yaml] (default: yaml)', /^(screen|json|yaml|yml)$/, 'yaml')
+    .option('-m, --map-consumers <value>', 'Specify consumer attribute to map consumer_id to when dumping. Can be either username or custom_id. (default: no mapping)', /^(username|custom_id)$/, false)
     .option('--host <value>', 'Kong admin host (default: localhost:8001)', 'localhost:8001')
     .option('--https', 'Use https for admin API requests')
     .option('--ignore-consumers', 'Ignore consumers in kong')
@@ -36,10 +38,11 @@ headers
     .map((h) => h.split(':'))
     .forEach(([name, value]) => requester.addHeader(name, value));
 
-readKongApi(adminApi({ host: program.host, https: program.https, ignoreConsumers: program.ignoreConsumers }))
+readKongApi(adminApi({ host: program.host, https: program.https }))
     .then(results => {
         return {host: program.host, https: program.https, headers, ...results};
     })
+    .then(mapConsumers(program.ignoreConsumers, program.mapConsumers))
     .then(pretty(program.format))
     .then(config => {
         process.stdout.write(config + '\n');

--- a/src/core.js
+++ b/src/core.js
@@ -402,8 +402,10 @@ function pluginConsumerId(world, plugin) {
         else if (plugin.hasOwnProperty('attributes') && plugin.attributes.consumer_id) {
             consumerID = plugin.attributes.consumer_id;
         }
-        if (consumerID && !plugin.attributes) {
-            plugin.attributes = {};
+        if (consumerID) {
+            if (!plugin.attributes) {
+                plugin.attributes = {};
+            }
             plugin.attributes.consumer_id = consumerID;
         }
         return consumerID

--- a/src/core.js
+++ b/src/core.js
@@ -231,6 +231,20 @@ function _createWorld({apis, consumers, plugins, version}) {
             return world.getConsumer(username).id;
         },
 
+        getConsumerByCustomId: custom_id => {
+            const consumer = consumers.find(c => c.custom_id === custom_id);
+
+            if (!consumer) {
+                throw new Error(`Unable to find consumer ${custom_id}`);
+            }
+
+            return consumer;
+        },
+
+        getConsumerIdByCustomId: custom_id => {
+            return world.getConsumerByCustomId(custom_id).id;
+        },
+
         getConsumerCredential: (username, name, attributes) => {
             const consumer = consumers.find(c => c.username === username);
 
@@ -374,11 +388,28 @@ function validateApiRequiredAttributes(api) {
 
 }
 
+//Determain the consumerID from a given config
+function pluginConsumerId(world, plugin) {
+        var consumerID = undefined;
+        if (plugin.username) {
+            consumerID = world.getConsumerId(plugin.username);
+            console.log("  - Found consumer_id", `${consumerID}`.bold, "for username", `${plugin.username}`.bold, ". Substituting consumer_id");
+        }
+        else if (plugin.custom_id) {
+            consumerID = world.getConsumerIdByCustomId(plugin.custom_id);
+            console.log("  - Found consumer_id", `${consumerID}`.bold, "for custom_id", `${plugin.custom_id}`.bold, ". Substituting consumer_id");
+        }
+        else if (plugin.hasOwnProperty('attributes') && plugin.attributes.consumer_id) {
+            consumerID = plugin.attributes.consumer_id;
+        }
+        return consumerID
+}
+
 function _plugin(apiName, plugin) {
     validateEnsure(plugin.ensure);
 
     return world => {
-        const consumerID = plugin.hasOwnProperty('attributes') ? plugin.attributes.consumer_id : undefined;
+        var consumerID = pluginConsumerId(world, plugin)
         if (plugin.ensure == 'removed') {
             if (world.hasPlugin(apiName, plugin.name, consumerID)) {
                 return removeApiPlugin(world.getApiId(apiName), world.getPluginId(apiName, plugin.name, consumerID));
@@ -403,7 +434,7 @@ function _globalPlugin(plugin) {
     validateEnsure(plugin.ensure);
 
     return world => {
-        const consumerID = plugin.hasOwnProperty('attributes') ? plugin.attributes.consumer_id : undefined;
+        var consumerID = pluginConsumerId(world, plugin)
         if (plugin.ensure == 'removed') {
             if (world.hasGlobalPlugin(plugin.name, consumerID)) {
                 return removeGlobalPlugin(world.getGlobalPluginId(plugin.name, consumerID));

--- a/src/core.js
+++ b/src/core.js
@@ -390,7 +390,7 @@ function validateApiRequiredAttributes(api) {
 
 //Determain the consumerID from a given config
 function pluginConsumerId(world, plugin) {
-        var consumerID = undefined;
+        let consumerID = undefined;
         if (plugin.username) {
             consumerID = world.getConsumerId(plugin.username);
             console.log("  - Found consumer_id", `${consumerID}`.bold, "for username", `${plugin.username}`.bold, ". Substituting consumer_id");
@@ -402,6 +402,10 @@ function pluginConsumerId(world, plugin) {
         else if (plugin.hasOwnProperty('attributes') && plugin.attributes.consumer_id) {
             consumerID = plugin.attributes.consumer_id;
         }
+        if (consumerID && !plugin.attributes) {
+            plugin.attributes = {};
+            plugin.attributes.consumer_id = consumerID;
+        }
         return consumerID
 }
 
@@ -409,7 +413,7 @@ function _plugin(apiName, plugin) {
     validateEnsure(plugin.ensure);
 
     return world => {
-        var consumerID = pluginConsumerId(world, plugin)
+        var consumerID = pluginConsumerId(world, plugin);
         if (plugin.ensure == 'removed') {
             if (world.hasPlugin(apiName, plugin.name, consumerID)) {
                 return removeApiPlugin(world.getApiId(apiName), world.getPluginId(apiName, plugin.name, consumerID));
@@ -434,7 +438,7 @@ function _globalPlugin(plugin) {
     validateEnsure(plugin.ensure);
 
     return world => {
-        var consumerID = pluginConsumerId(world, plugin)
+        var consumerID = pluginConsumerId(world, plugin);
         if (plugin.ensure == 'removed') {
             if (world.hasGlobalPlugin(plugin.name, consumerID)) {
                 return removeGlobalPlugin(world.getGlobalPluginId(plugin.name, consumerID));

--- a/src/mapConsumers.js
+++ b/src/mapConsumers.js
@@ -1,0 +1,52 @@
+export default (ignoreConsumers, mapType) => {
+    return config => removeConsumers(translateConsumers(config, mapType), ignoreConsumers);
+}
+
+function translateConsumers(config, mapType) {
+    if (mapType) {
+        config['apis'] = mapApis(config['apis'], config['consumers'], mapType);
+        config['plugins'] = mapPlugins(config['plugins'], config['consumers'], mapType);
+    } 
+    return config;
+}
+
+function removeConsumers(config, ignoreConsumers) {
+    if (ignoreConsumers) {
+        config['consumers'] = [];
+    }
+
+    return config;
+}
+
+
+function mapApis(apis, consumers, mapType) {
+    apis.forEach(function(api) {
+        api.plugins = mapPlugins(api.plugins, consumers, mapType);
+    });
+    return apis
+}
+
+function mapPlugins(plugins, consumers, mapType) {
+    plugins.forEach(function(plugin) {
+        if (plugin.attributes && plugin.attributes.consumer_id) {
+            var consumer = getConsumer(plugin.attributes.consumer_id, consumers);
+            if (!consumer[mapType]) {
+                throw new Error(`Unable to map consumer. ${consumer.id} has no ${mapType}.`);
+            }
+            plugin[mapType] = consumer[mapType];
+            delete plugin.attributes.consumer_id;
+        }
+    });
+    return plugins
+}
+
+
+
+function getConsumer(id, consumers) {
+    const consumer = consumers.find(c => c.id === id);
+    if (!consumer) {
+        throw new Error(`Unable to find consumer ${id}.`);
+    }
+
+    return consumer
+}

--- a/src/readKongApi.js
+++ b/src/readKongApi.js
@@ -17,10 +17,11 @@ export default async (adminApi) => {
 };
 
 function parseConsumers(consumers) {
-    return consumers.map(({username, custom_id, credentials, acls, ..._info}) => {
+    return consumers.map(({username, custom_id, id, credentials, acls, ..._info}) => {
         return {
             username,
             custom_id,
+            id,
             _info,
             acls: Array.isArray(acls) ? acls.map(({group, ..._info}) => ({group, _info})) : [],
             credentials: zip(Object.keys(credentials), Object.values(credentials))


### PR DESCRIPTION
Support the use of username and custom_ids when configuring plugins.

When dumping, a mapping can be done to username *or* custom_id.

When applying a config, *mixed* use of username, custom_id and consumer_id is allowed. That is also the order of precedence in multiple attributes are specified. 