### PR TITLE
Check if Kong version is a release candidate

### DIFF
--- a/src/readKongApi.js
+++ b/src/readKongApi.js
@@ -54,7 +54,8 @@ function parseCredential([credentialName, credentials]) {
 }
 
 function parseApis(apis, kongVersion) {
-    if (semVer.gte(kongVersion, '0.10.0')) {
+
+    if (kongVersion.includes("rc") || semVer.gte(kongVersion, '0.10.0')) {
         return parseApisV10(apis);
     }
 

--- a/src/readKongApi.js
+++ b/src/readKongApi.js
@@ -54,7 +54,6 @@ function parseCredential([credentialName, credentials]) {
 }
 
 function parseApis(apis, kongVersion) {
-
     if (kongVersion.includes("rc") || semVer.gte(kongVersion, '0.10.0')) {
         return parseApisV10(apis);
     }


### PR DESCRIPTION
Closes #86

I found that the error was due to the semantic versioning check. Kong guys didn't add the necessary `-` for the release candidate to be compliant with http://semver.org/. It should be `0.11.0-rc1` in stead of `0.11.0rc1`.