### PR TITLE
Override default paginated next uri returned by kong to configured

### DIFF
--- a/src/adminApi.js
+++ b/src/adminApi.js
@@ -96,8 +96,9 @@ function getPaginatedJson(uri) {
             // FIXME an hopeful hack to prevent a loop
             return json.data;
         }
-
-        return getPaginatedJson(json.next).then(data => json.data.concat(data));
+        
+        const nextUri = `${uri}?${json.next.split('?')[1]}`;
+        return getPaginatedJson(nextUri).then(data => json.data.concat(data));
     });
 }
 


### PR DESCRIPTION
For issue #90.
1. Takes the query param from returned next uri
2. Appends it to the configured uri.
3. Continue as normal