### PR TITLE
add support for kong enterprise version scheme

### DIFF
--- a/src/adminApi.js
+++ b/src/adminApi.js
@@ -1,5 +1,6 @@
 import createRouter from './router';
 import requester from './requester';
+import { parseVersion } from './utils.js'
 
 let pluginSchemasCache;
 let kongVersionCache;
@@ -44,7 +45,7 @@ function createApi({ router, getPaginatedJson, ignoreConsumers }) {
 
             return getPaginatedJson(router({name: 'root'}))
                 .then(json => Promise.resolve(json.version))
-                .then(version => kongVersionCache = version);
+                .then(version => kongVersionCache = parseVersion(version));
         },
         requestEndpoint: (endpoint, params) => {
             resultsCache = {};

--- a/src/utils.js
+++ b/src/utils.js
@@ -11,9 +11,9 @@ export function normalize(attr) {
     return mutable;
 }
 
-function _setOnPath(obj, path, value){
+function _setOnPath(obj, path, value) {
     if (!path) {
-      return obj;
+        return obj;
     }
 
     var currentPath = path[0];
@@ -34,7 +34,30 @@ function _setOnPath(obj, path, value){
     return _setOnPath(obj[currentPath], path.slice(1), value);
 }
 
-export function repeatableOptionCallback(val, result){
+export function repeatableOptionCallback(val, result) {
     result.push(val);
     return result;
+}
+
+export function parseVersion(version) {
+    if (!version.includes("enterprise-edition")) {
+        // remove any postfix, i.e., 0.11.0-rc1 should be 0.11.0
+        return version.split("-")[0];
+    }
+
+    // Kong EE versioning is X.Y(-Z)-enterprise-edition
+    var vAry = version.split("-")
+
+    if (vAry.length == 4) {
+        version = vAry[0] + "." + vAry[1]
+    } else {
+        version = vAry[0];
+    }
+
+    // add .0 so that kong EE has a patch version, i.e, 0.29 should be 0.29.0
+    if (version.split(".").length == 2) {
+        version = version + ".0"
+    }
+
+    return version
 }

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,5 +1,5 @@
 import expect from 'expect.js';
-import {normalize} from '../src/utils'
+import {normalize, parseVersion} from '../src/utils'
 
 describe("normalize utils", () => {
     it("should normalize attributes", () => {
@@ -33,5 +33,27 @@ describe("normalize utils", () => {
 
         expect(normalize(attr)).to.be.eql({config: { foobar: ["a", "b"] }});
         expect(actual.config.foobar).to.be.an('array');
+    });
+});
+
+describe("parseVersion utils", () => {
+    it("should return the CE version", () => {
+        expect(parseVersion("0.10.0")).to.be.eql("0.10.0");
+    });
+
+    it("should return the CE version", () => {
+        expect(parseVersion("0.11.0-rc1")).to.be.eql("0.11.0");
+    });
+
+    it("should return the EE version", () => {
+        expect(parseVersion("0.29-0-enterprise-edition")).to.be.eql("0.29.0");
+    });
+
+    it("should return the EE version", () => {
+        expect(parseVersion("0.29-1-enterprise-edition")).to.be.eql("0.29.1");
+    });
+
+    it("should return the EE version with no patch", () => {
+        expect(parseVersion("0.29-enterprise-edition")).to.be.eql("0.29.0");
     });
 });


### PR DESCRIPTION
This should address https://github.com/mybuilder/kongfig/issues/109 and https://github.com/mybuilder/kongfig/issues/86. 

All tests pass agains CE edition. I noticed some of the integration tests fail for some of the plugins on EE editions. I will try to followup on those in a separate PR.