### PR TITLE
Add censoring log data

### DIFF
--- a/src/logger.js
+++ b/src/logger.js
@@ -6,13 +6,24 @@ const createLogHandler = handlers => message => {
     return handlers['unknown'](message);
 };
 
+const censoredKeys = ['key', 'password', 'client_secret', 'access_token', 'refresh_token', 'provision_key', 'secret', 'cert'];
+
+const censor = (key, value) => {
+    if (typeof value !== 'string') {
+        return value;
+    }
+
+    return censoredKeys.indexOf(key) === -1 ? value : `*****${value.slice(-4)}`;
+};
+const censorLogData = data => JSON.parse(JSON.stringify(data, censor));
+
 export const screenLogger = createLogHandler({
     noop: message => createLogHandler({
         'noop-api': ({ api }) => console.log(`api ${api.name.bold} ${'is up to date'.bold.green}`),
         'noop-plugin': ({ plugin }) => console.log(`- plugin ${plugin.name.bold} ${'is up to date'.bold.green}`),
         'noop-global-plugin': ({ plugin }) => console.log(`global plugin ${plugin.name.bold} ${'is up to date'.bold.green}`),
         'noop-consumer': ({ consumer }) => console.log(`consumer ${consumer.username.bold} ${'is up to date'.bold.green}`),
-        'noop-credential': ({ credential, credentialIdName }) => console.log(`- credential ${credential.name.bold} with ${credentialIdName.bold}: ${credential.attributes[credentialIdName].bold} ${'is up to date'.bold.green}`),
+        'noop-credential': ({ credential, credentialIdName }) => console.log(`- credential ${credential.name.bold} with ${credentialIdName.bold}: ${censor('key', credential.attributes[credentialIdName]).bold} ${'is up to date'.bold.green}`),
         'noop-upstream': ({ upstream }) => console.log(`upstream ${upstream.name.bold} ${'is up to date'.bold.green}`),
         'noop-target': ({ target }) => console.log(`target ${target.target.bold} ${'is up to date'.bold.green}`),
         'noop-certificate': ({ identityClue }) => console.log(`certificate ${identityClue}... ${'is up to date'.bold.green}`),
@@ -22,11 +33,11 @@ export const screenLogger = createLogHandler({
         unknown: action => console.log('unknown action', action),
     })(message.params),
     request: ({ uri, params: { method, body } }) => console.log(
-        `\n${method.bold.blue}`, uri.blue, "\n", body ? body : ''
+        `\n${method.bold.blue}`, uri.blue, "\n", body ? censorLogData(body) : ''
     ),
     response: ({ ok, status, statusText, content }) => console.log(
         ok ? `${status} ${statusText.bold}`.green : `${status} ${statusText.bold}`.red,
-        content
+        censorLogData(content)
     ),
     debug: () => {},
     'experimental-features': ({ message }) => console.log(message),


### PR DESCRIPTION
Censor sensitive information from log output.

Have a look at `censoredKeys` to suggest more.

```
POST http://localhost:8001/consumers 
 { username: 'iphone-app' }
201 Created { created_at: 1517869952000,
  username: 'iphone-app',
  id: 'f56183e5-4477-45b6-9c67-e1ee53554141' }

POST http://localhost:8001/consumers/f56183e5-4477-45b6-9c67-e1ee53554141/key-auth 
 { key: '*****gtPO' }
201 Created { id: '885144e7-d499-40cf-ac7f-e7740276d065',
  created_at: 1517869953000,
  key: '*****gtPO',
  consumer_id: 'f56183e5-4477-45b6-9c67-e1ee53554141' }
```