### PR TITLE
Allow infinite (n) optional version segments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
   global:
     - TEST_INTEGRATION_KONG_HOST="127.0.0.1:8001"
     - KONG_VERSION=0.13.0rc1-alpine
+    - KONG_VERSION=0.11.0.3-enterprise-edition
   matrix:
     - EXPERIMENTAL_USE_LOCAL_STATE=0
     - EXPERIMENTAL_USE_LOCAL_STATE=1

--- a/src/utils.js
+++ b/src/utils.js
@@ -42,24 +42,25 @@ export function repeatableOptionCallback(val, result) {
 }
 
 export function parseVersion(version) {
-    if (!version.includes("enterprise-edition")) {
-        // remove any postfix, i.e., 0.11.0-rc1 should be 0.11.0
-        return semVer.coerce(version).version;
-    }
-
-    // Kong EE versioning is X.Y(-Z)-enterprise-edition
-    var vAry = version.split("-")
-
-    if (vAry.length == 4) {
-        version = vAry[0] + "." + vAry[1]
-    } else {
-        version = vAry[0];
-    }
-
-    // add .0 so that kong EE has a patch version, i.e, 0.29 should be 0.29.0
-    if (version.split(".").length == 2) {
-        version = version + ".0"
-    }
-
     return semVer.coerce(version).version;
+    // if (!version.includes("enterprise-edition")) {
+    //     // remove any postfix, i.e., 0.11.0-rc1 should be 0.11.0
+    //     return semVer.coerce(version).version;
+    // }
+    //
+    // // Kong EE versioning is X.Y(-Z)-enterprise-edition
+    // var vAry = version.split("-")
+    //
+    // if (vAry.length == 4) {
+    //     version = vAry[0] + "." + vAry[1]
+    // } else {
+    //     version = vAry[0];
+    // }
+    //
+    // // add .0 so that kong EE has a patch version, i.e, 0.29 should be 0.29.0
+    // if (version.split(".").length == 2) {
+    //     version = version + ".0"
+    // }
+    //
+    // return semVer.coerce(version).version;
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -43,24 +43,4 @@ export function repeatableOptionCallback(val, result) {
 
 export function parseVersion(version) {
     return semVer.coerce(version).version;
-    // if (!version.includes("enterprise-edition")) {
-    //     // remove any postfix, i.e., 0.11.0-rc1 should be 0.11.0
-    //     return semVer.coerce(version).version;
-    // }
-    //
-    // // Kong EE versioning is X.Y(-Z)-enterprise-edition
-    // var vAry = version.split("-")
-    //
-    // if (vAry.length == 4) {
-    //     version = vAry[0] + "." + vAry[1]
-    // } else {
-    //     version = vAry[0];
-    // }
-    //
-    // // add .0 so that kong EE has a patch version, i.e, 0.29 should be 0.29.0
-    // if (version.split(".").length == 2) {
-    //     version = version + ".0"
-    // }
-    //
-    // return semVer.coerce(version).version;
 }

--- a/test/utils.js
+++ b/test/utils.js
@@ -57,6 +57,10 @@ describe("parseVersion utils", () => {
         expect(parseVersion("0.29-enterprise-edition")).to.be.eql("0.29.0");
     });
 
+    it("should return the EE version with additional build number", () => {
+        expect(parseVersion("0.11.0.3-enterprise-edition")).to.be.eql("0.11.0");
+    });
+
     it("should fix pre-release versions", () => {
         expect(parseVersion("0.13.1rc")).to.be.eql('0.13.1');
     });


### PR DESCRIPTION
We have `0.11.0.3-enterprise-edition` use-case.