### PR TITLE
Fix repetitive consumer credential deletion

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -681,6 +681,8 @@ function _consumerCredential(username, credential) {
                 return removeConsumerCredentials(world.getConsumerId(username), credential.name, credentialId);
             }
 
+            const credentialIdName = getConsumerCredentialSchema(credential.name).id;
+            
             return noop({ type: 'noop-credential', credential, credentialIdName });
         }
 


### PR DESCRIPTION
`credentialIdName` variable wasn't declared in `core._consumerCredential` in the case where a credential was marked as removed and was indeed already removed from Kong.