### PR TITLE
Retrying failed GETs

### DIFF
--- a/src/requester.js
+++ b/src/requester.js
@@ -49,7 +49,17 @@ function fetchWithRetry(url, options) {
     var wrappedFetch = (n) => {
       fetch(url, options)
         .then(response => {
-          resolve(response);
+          if(options.method == "GET" && !response.ok) {
+            if(n <= retries) {
+              setTimeout(() => {
+                wrappedFetch(n + 1);
+              }, retryDelay * Math.pow(2, n));
+            } else {
+              reject(error);
+            }
+          } else {
+            resolve(response);
+          }
         })
         .catch(error => {
           if (n <= retries) {


### PR DESCRIPTION
Currently, only network failures are retried in the requester. I added this for failed GETs as well. This is important when Kong's admin endpoint gets too many request in too short a time, for example when loading a lot of configuration for each API.