### PR TITLE
Fix paginated json uri

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "object-assign": "^4.0.1",
     "pad": "^2.0.3",
     "prettyjson": "^1.1.3",
-    "semver": "^5.5.0"
+    "semver": "^5.5.0",
+    "url": "^0.11.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/src/adminApi.js
+++ b/src/adminApi.js
@@ -1,6 +1,7 @@
 import createRouter from './router';
 import requester from './requester';
-import { parseVersion } from './utils.js'
+import { parseVersion } from './utils.js';
+import { parse, format } from 'url';
 
 let pluginSchemasCache;
 let kongVersionCache;
@@ -80,6 +81,13 @@ function getPluginScheme(plugin, schemaRoute) {
         .then(({fields}) => [plugin, fields]);
 }
 
+function fixNextUri(uri, nextUri) {
+    const { protocol, auth, hostname, port, pathname, path } = parse(uri);
+    const { hash, search, query } = parse(nextUri);
+
+    return format({ protocol, auth, hostname, port, hash, search, query, pathname, path });
+}
+
 function getPaginatedJson(uri) {
     return requester.get(uri)
     .then(response => {
@@ -110,7 +118,7 @@ function getPaginatedJson(uri) {
             return json.data;
         }
 
-        return getPaginatedJson(json.next).then(data => json.data.concat(data));
+        return getPaginatedJson(fixNextUri(uri, json.next)).then(data => json.data.concat(data));
     });
 }
 


### PR DESCRIPTION
When accessing the kong admin through a proxy, the `next` field in the json response includes a uri referencing `localhost:8001`, or wherever kong is running, rather than the uri used to access kong.

This PR fixes #118 and modifies the next uri to use the original uri, with the addition of the hash, search and query params from the next url. This allows accessing the kong admin at a different host and/or path.

This is a slightly modified version of @CyExy's #123 