### PR TITLE
Add option to limit request concurrency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kongfig",
-  "version": "1.6.0",
+  "version": "1.5.3",
   "description": "A tool for Kong to allow declarative configuration.",
   "repository": "https://github.com/mybuilder/kongfig",
   "bin": {
@@ -51,7 +51,6 @@
     "transformIgnorePatterns": [
       "<rootDir>/node_modules/",
       "<rootDir>/lib/"
-    ],
-    "testURL": "http://localhost/"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "kongfig",
-  "version": "1.5.3",
+  "name": "cloud-elements/kongfig",
+  "version": "1.6.0",
   "description": "A tool for Kong to allow declarative configuration.",
   "repository": "https://github.com/mybuilder/kongfig",
   "bin": {
@@ -20,6 +20,7 @@
   "license": "MIT",
   "dependencies": {
     "babel-polyfill": "^6.26.0",
+    "bluebird": "^3.5.3",
     "colors": "^1.1.2",
     "commander": "^2.13.0",
     "invariant": "^2.2.2",
@@ -50,6 +51,7 @@
     "transformIgnorePatterns": [
       "<rootDir>/node_modules/",
       "<rootDir>/lib/"
-    ]
+    ],
+    "testURL": "http://localhost/"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cloud-elements/kongfig",
+  "name": "kongfig",
   "version": "1.6.0",
   "description": "A tool for Kong to allow declarative configuration.",
   "repository": "https://github.com/mybuilder/kongfig",

--- a/src/adminApi.js
+++ b/src/adminApi.js
@@ -7,17 +7,18 @@ let pluginSchemasCache;
 let kongVersionCache;
 let resultsCache = {};
 
-export default ({host, https, ignoreConsumers, cache}) => {
+export default ({host, https, ignoreConsumers, cache, concurrency}) => {
     const router = createRouter(host, https);
 
     return createApi({
         router,
         ignoreConsumers,
         getPaginatedJson: cache ? getPaginatedJsonCache : getPaginatedJson,
+        concurrency,
     });
 }
 
-function createApi({ router, getPaginatedJson, ignoreConsumers }) {
+function createApi({ router, getPaginatedJson, ignoreConsumers, concurrency }) {
     return {
         router,
         fetchApis: () => getPaginatedJson(router({name: 'apis'})),
@@ -38,7 +39,7 @@ function createApi({ router, getPaginatedJson, ignoreConsumers }) {
             }
 
             return getPaginatedJson(router({name: 'plugins-enabled'}))
-                .then(json => Promise.map(getEnabledPluginNames(json.enabled_plugins), plugin => getPluginScheme(plugin, plugin => router({name: 'plugins-scheme', params: {plugin}})), {concurrency: 5}))
+                .then(json => Promise.map(getEnabledPluginNames(json.enabled_plugins), plugin => getPluginScheme(plugin, plugin => router({name: 'plugins-scheme', params: {plugin}})), {concurrency}))
                 .then(all => pluginSchemasCache = new Map(all));
         },
         fetchKongVersion: () => {

--- a/src/adminApi.js
+++ b/src/adminApi.js
@@ -54,7 +54,8 @@ function createApi({ router, getPaginatedJson, ignoreConsumers, concurrency }) {
         requestEndpoint: (endpoint, params) => {
             resultsCache = {};
             return requester.request(router(endpoint), prepareOptions(params));
-        }
+        },
+        concurrency
     };
 }
 

--- a/src/adminApi.js
+++ b/src/adminApi.js
@@ -1,3 +1,4 @@
+import Promise from 'bluebird';
 import createRouter from './router';
 import requester from './requester';
 import { parseVersion } from './utils.js'
@@ -37,7 +38,7 @@ function createApi({ router, getPaginatedJson, ignoreConsumers }) {
             }
 
             return getPaginatedJson(router({name: 'plugins-enabled'}))
-                .then(json => Promise.all(getEnabledPluginNames(json.enabled_plugins).map(plugin => getPluginScheme(plugin, plugin => router({name: 'plugins-scheme', params: {plugin}})))))
+                .then(json => Promise.map(getEnabledPluginNames(json.enabled_plugins), plugin => getPluginScheme(plugin, plugin => router({name: 'plugins-scheme', params: {plugin}})), {concurrency: 5}))
                 .then(all => pluginSchemasCache = new Map(all));
         },
         fetchKongVersion: () => {

--- a/src/cli-apply.js
+++ b/src/cli-apply.js
@@ -17,7 +17,7 @@ program
     .option('--ignore-consumers', 'Do not sync consumers')
     .option('--header [value]', 'Custom headers to be added to all requests', (nextHeader, headers) => { headers.push(nextHeader); return headers }, [])
     .option('--credential-schema <value>', 'Add custom auth plugin in <name>:<key> format. Ex: custom_jwt:key. Repeat option for multiple custom plugins', repeatableOptionCallback, [])
-    .option('--concurrency <value>', 'Limit concurrent requests (default: 8)')
+    .option('--concurrency <value>', 'Limit concurrent requests (default: 8)', 8)
     .parse(process.argv);
 
 if (!program.path) {

--- a/src/cli-apply.js
+++ b/src/cli-apply.js
@@ -17,7 +17,7 @@ program
     .option('--ignore-consumers', 'Do not sync consumers')
     .option('--header [value]', 'Custom headers to be added to all requests', (nextHeader, headers) => { headers.push(nextHeader); return headers }, [])
     .option('--credential-schema <value>', 'Add custom auth plugin in <name>:<key> format. Ex: custom_jwt:key. Repeat option for multiple custom plugins', repeatableOptionCallback, [])
-    .option('--concurrency <value>', 'Limit concurrent requests (default: 8)', 8)
+    .option('--concurrency <value>', 'Limit concurrent requests (default: 8)', parseInt)
     .parse(process.argv);
 
 if (!program.path) {

--- a/src/cli-apply.js
+++ b/src/cli-apply.js
@@ -17,6 +17,7 @@ program
     .option('--ignore-consumers', 'Do not sync consumers')
     .option('--header [value]', 'Custom headers to be added to all requests', (nextHeader, headers) => { headers.push(nextHeader); return headers }, [])
     .option('--credential-schema <value>', 'Add custom auth plugin in <name>:<key> format. Ex: custom_jwt:key. Repeat option for multiple custom plugins', repeatableOptionCallback, [])
+    .option('--concurrency <value>', 'Limit concurrent requests (default: 8)')
     .parse(process.argv);
 
 if (!program.path) {
@@ -38,6 +39,7 @@ let host = program.host || config.host || 'localhost:8001';
 let https = program.https || config.https || false;
 let ignoreConsumers = program.ignoreConsumers || !config.consumers || config.consumers.length === 0 || false;
 let cache = program.cache;
+let concurrency = program.concurrency || 8;
 
 config.headers = config.headers || [];
 
@@ -68,7 +70,7 @@ else {
 
 console.log(`Apply config to ${host}`.green);
 
-execute(config, adminApi({host, https, ignoreConsumers, cache}), screenLogger)
+execute(config, adminApi({host, https, ignoreConsumers, cache, concurrency}), screenLogger)
   .catch(error => {
       console.error(`${error}`.red, '\n', error.stack);
       process.exit(1);

--- a/src/cli-dump.js
+++ b/src/cli-dump.js
@@ -16,7 +16,7 @@ program
     .option('--ignore-consumers', 'Ignore consumers in kong')
     .option('--header [value]', 'Custom headers to be added to all requests', (nextHeader, headers) => { headers.push(nextHeader); return headers }, [])
     .option('--credential-schema <value>', 'Add custom auth plugin in <name>:<key> format. Ex: custom_jwt:key. Repeat option for multiple custom plugins', repeatableOptionCallback, [])
-    .option('--concurrency <value>', 'Limit concurrent requests (default: 8)', 8)
+    .option('--concurrency <value>', 'Limit concurrent requests (default: 8)', parseInt)
     .parse(process.argv);
 
 if (!program.host) {

--- a/src/cli-dump.js
+++ b/src/cli-dump.js
@@ -16,7 +16,7 @@ program
     .option('--ignore-consumers', 'Ignore consumers in kong')
     .option('--header [value]', 'Custom headers to be added to all requests', (nextHeader, headers) => { headers.push(nextHeader); return headers }, [])
     .option('--credential-schema <value>', 'Add custom auth plugin in <name>:<key> format. Ex: custom_jwt:key. Repeat option for multiple custom plugins', repeatableOptionCallback, [])
-    .option('--concurrency <value>', 'Limit concurrent requests (default: 8)')
+    .option('--concurrency <value>', 'Limit concurrent requests (default: 8)', 8)
     .parse(process.argv);
 
 if (!program.host) {

--- a/src/cli-dump.js
+++ b/src/cli-dump.js
@@ -16,6 +16,7 @@ program
     .option('--ignore-consumers', 'Ignore consumers in kong')
     .option('--header [value]', 'Custom headers to be added to all requests', (nextHeader, headers) => { headers.push(nextHeader); return headers }, [])
     .option('--credential-schema <value>', 'Add custom auth plugin in <name>:<key> format. Ex: custom_jwt:key. Repeat option for multiple custom plugins', repeatableOptionCallback, [])
+    .option('--concurrency <value>', 'Limit concurrent requests (default: 8)')
     .parse(process.argv);
 
 if (!program.host) {
@@ -31,12 +32,13 @@ try {
 }
 
 let headers = program.header || [];
+let concurrency = program.concurrency || 8;
 
 headers
     .map((h) => h.split(':'))
     .forEach(([name, value]) => requester.addHeader(name, value));
 
-readKongApi(adminApi({ host: program.host, https: program.https, ignoreConsumers: program.ignoreConsumers }))
+readKongApi(adminApi({ host: program.host, https: program.https, ignoreConsumers: program.ignoreConsumers, concurrency }))
     .then(results => {
         return {host: program.host, https: program.https, headers, ...results};
     })

--- a/src/kongState.js
+++ b/src/kongState.js
@@ -1,4 +1,5 @@
 import semVer from 'semver';
+import Promise from 'bluebird';
 import {getSupportedCredentials} from './consumerCredentials'
 
 const fetchUpstreamsWithTargets = async ({ version, fetchUpstreams, fetchTargets }) => {
@@ -8,13 +9,11 @@ const fetchUpstreamsWithTargets = async ({ version, fetchUpstreams, fetchTargets
 
     const upstreams = await fetchUpstreams();
 
-    return await Promise.all(
-        upstreams.map(async item => {
-            const targets = await fetchTargets(item.id);
+    return await Promise.map(upstreams, async item => {
+        const targets = await fetchTargets(item.id);
 
-            return { ...item, targets };
-        })
-    );
+        return { ...item, targets };
+    }, {concurrency: 5});
 };
 
 const fetchCertificatesForVersion = async ({ version, fetchCertificates }) => {
@@ -28,24 +27,24 @@ const fetchCertificatesForVersion = async ({ version, fetchCertificates }) => {
 export default async ({fetchApis, fetchPlugins, fetchGlobalPlugins, fetchConsumers, fetchConsumerCredentials, fetchConsumerAcls, fetchUpstreams, fetchTargets, fetchTargetsV11Active, fetchCertificates, fetchKongVersion}) => {
     const version = await fetchKongVersion();
     const apis = await fetchApis();
-    const apisWithPlugins = await Promise.all(apis.map(async item => {
+    const apisWithPlugins = await Promise.map(apis, async item => {
         const plugins =  await fetchPlugins(item.id);
 
         return {...item, plugins};
-    }));
+    }, {concurrency: 5});
 
     const consumers = await fetchConsumers();
-    const consumersWithCredentialsAndAcls = await Promise.all(consumers.map(async consumer => {
+    const consumersWithCredentialsAndAcls = await Promise.map(consumers, async consumer => {
         if (consumer.custom_id && !consumer.username) {
             console.log(`Consumers with only custom_id not supported: ${consumer.custom_id}`);
 
             return consumer;
         }
 
-        const allCredentials = Promise.all(getSupportedCredentials().map(name => {
+        const allCredentials = Promise.map(getSupportedCredentials(), name => {
             return fetchConsumerCredentials(consumer.id, name)
                 .then(credentials => [name, credentials]);
-        }));
+        }, {concurrency: 5});
 
         var aclsFetched = await fetchConsumerAcls(consumer.id);
 
@@ -63,7 +62,7 @@ export default async ({fetchApis, fetchPlugins, fetchGlobalPlugins, fetchConsume
 
         return consumerWithCredentials;
 
-    }));
+    }, {concurrency: 5});
 
     const allPlugins = await fetchGlobalPlugins();
     const globalPlugins = allPlugins.filter(plugin => {

--- a/src/kongState.js
+++ b/src/kongState.js
@@ -2,7 +2,7 @@ import semVer from 'semver';
 import Promise from 'bluebird';
 import {getSupportedCredentials} from './consumerCredentials'
 
-const fetchUpstreamsWithTargets = async ({ version, fetchUpstreams, fetchTargets }) => {
+const fetchUpstreamsWithTargets = async ({ version, fetchUpstreams, fetchTargets, concurrency }) => {
     if (semVer.lte(version, '0.10.0')) {
         return Promise.resolve([]);
     }
@@ -13,7 +13,7 @@ const fetchUpstreamsWithTargets = async ({ version, fetchUpstreams, fetchTargets
         const targets = await fetchTargets(item.id);
 
         return { ...item, targets };
-    }, {concurrency: 5});
+    }, {concurrency});
 };
 
 const fetchCertificatesForVersion = async ({ version, fetchCertificates }) => {
@@ -24,14 +24,14 @@ const fetchCertificatesForVersion = async ({ version, fetchCertificates }) => {
     return await fetchCertificates();
 };
 
-export default async ({fetchApis, fetchPlugins, fetchGlobalPlugins, fetchConsumers, fetchConsumerCredentials, fetchConsumerAcls, fetchUpstreams, fetchTargets, fetchTargetsV11Active, fetchCertificates, fetchKongVersion}) => {
+export default async ({fetchApis, fetchPlugins, fetchGlobalPlugins, fetchConsumers, fetchConsumerCredentials, fetchConsumerAcls, fetchUpstreams, fetchTargets, fetchTargetsV11Active, fetchCertificates, fetchKongVersion, concurrency}) => {
     const version = await fetchKongVersion();
     const apis = await fetchApis();
     const apisWithPlugins = await Promise.map(apis, async item => {
         const plugins =  await fetchPlugins(item.id);
 
         return {...item, plugins};
-    }, {concurrency: 5});
+    }, {concurrency});
 
     const consumers = await fetchConsumers();
     const consumersWithCredentialsAndAcls = await Promise.map(consumers, async consumer => {
@@ -44,7 +44,7 @@ export default async ({fetchApis, fetchPlugins, fetchGlobalPlugins, fetchConsume
         const allCredentials = Promise.map(getSupportedCredentials(), name => {
             return fetchConsumerCredentials(consumer.id, name)
                 .then(credentials => [name, credentials]);
-        }, {concurrency: 5});
+        }, {concurrency});
 
         var aclsFetched = await fetchConsumerAcls(consumer.id);
 
@@ -62,14 +62,14 @@ export default async ({fetchApis, fetchPlugins, fetchGlobalPlugins, fetchConsume
 
         return consumerWithCredentials;
 
-    }, {concurrency: 5});
+    }, {concurrency});
 
     const allPlugins = await fetchGlobalPlugins();
     const globalPlugins = allPlugins.filter(plugin => {
         return plugin.api_id === undefined;
     });
 
-    const upstreamsWithTargets = await fetchUpstreamsWithTargets({ version, fetchUpstreams, fetchTargets: semVer.gte(version, '0.12.0') ? fetchTargets : fetchTargetsV11Active });
+    const upstreamsWithTargets = await fetchUpstreamsWithTargets({ version, fetchUpstreams, fetchTargets: semVer.gte(version, '0.12.0') ? fetchTargets : fetchTargetsV11Active, concurrency });
     const certificates = await fetchCertificatesForVersion({ version, fetchCertificates });
 
     return {

--- a/test-integration/util.js
+++ b/test-integration/util.js
@@ -28,6 +28,7 @@ export const testAdminApi = adminApi({
     https: false,
     ignoreConsumers: false,
     cache: false,
+    concurrency: 8,
 });
 
 export const getLog = () => log;


### PR DESCRIPTION
Add command line option to limit concurrency for dump and apply operations. Uses Bluebird `Promise.map` to limit concurrent requests. This resolves an issue we were seeing with a large number of concurrent admin API requests causing 500 errors during the `kongfig apply` operation.